### PR TITLE
feat(stream): Copy all user-provided query parameters to a new request

### DIFF
--- a/handlers/const.go
+++ b/handlers/const.go
@@ -17,7 +17,7 @@ const (
 	API_FINANCES          = "https://myhome.novotelecom.ru/rest/v1/subscribers/profiles/finances"
 	API_SUBSCRIBER_PLACES = "https://myhome.novotelecom.ru/rest/v1/subscriberplaces"
 	API_VIDEO_SNAPSHOT    = "https://myhome.novotelecom.ru/rest/v1/places/%s/accesscontrols/%s/videosnapshots"
-	API_CAMERA_GET_STREAM = "https://myhome.novotelecom.ru/rest/v1/forpost/cameras/%s/video?&LightStream=0"
+	API_CAMERA_GET_STREAM = "https://myhome.novotelecom.ru/rest/v1/forpost/cameras/%s/video"
 	API_REFRESH_SESSION   = "https://myhome.novotelecom.ru/auth/v2/session/refresh"
 	API_EVENTS            = "https://myhome.novotelecom.ru/rest/v1/places/%s/events?allowExtentedActions=true"
 	API_OPERATORS         = "https://myhome.novotelecom.ru/public/v1/operators"

--- a/handlers/stream.go
+++ b/handlers/stream.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -23,9 +24,12 @@ func (h *Handler) Stream(r *http.Request) (string, error) {
 	query := r.URL.Query()
 	cameraID := query.Get("cameraID")
 
-	url := fmt.Sprintf(API_CAMERA_GET_STREAM, cameraID)
+	targetRawURL := fmt.Sprintf(API_CAMERA_GET_STREAM, cameraID)
 
-	request, err := http.NewRequest("GET", url, nil)
+	targetURL, _ := url.Parse(targetRawURL)
+	targetURL.RawQuery = r.URL.RawQuery
+
+	request, err := http.NewRequest("GET", targetURL.String(), nil)
 	if err != nil {
 		return body, err
 	}


### PR DESCRIPTION
Currently, there is no way to pass additional query parameters to http request. Original API supports several interesting params:

 - `TS=1679086457 & TZ=10800` - unix timestamp and timezone. Enables retrieving a video stream from a specific point in time. - Speed=3.0 - video stream will play at a certain speed.
  -  `LightStream=0` - Video quality (default is 0). 0 - 1920x1080, 1 - 960x528 Format=H264

What I've added - just copy all user-provided query parameters to new request.

This PR doesn't bring any breaking changes because LightStream=0 is the default value.
